### PR TITLE
Update to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@
 name: "Code signing with Software Trust Manager"
 description: "Code signing automation with private key protection and multi-factor authentication (MFA)"
 runs:
-  using: "node16"
+  using: "node20"
   main: "./build/index.js"
 branding:
   icon: "check-circle"


### PR DESCRIPTION
Node16 is deprecated and should be removed "by Spring 2024": https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

## Relevant links
* #18 