### PR TITLE
Node20 update

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,7 +3,10 @@
 
 name: SSMClientToolsSetup
 
-on: push
+on:
+  push:
+    branches:
+      - node20_update
 
 jobs:
   build:
@@ -15,9 +18,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - name: Install Software Trust Manager client tools
         id: STMClientToolsSetup
         run: |

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,7 +6,7 @@ name: SSMClientToolsSetup
 on:
   push:
     branches:
-      - node20_update
+      - master
 
 jobs:
   build:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -37,3 +37,4 @@ jobs:
 
     env:
       SSM_CLIENT_INSTALLER_READ_TOKEN: ${{ secrets.SSM_CLIENT_INSTALLER_READ_TOKEN }}
+

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@
 name: "Code signing with Software Trust Manager"
 description: "Code signing automation with private key protection and multi-factor authentication (MFA)"
 runs:
-  using: "node16"
+  using: "node20"
   main: "./build/index.js"
 branding:
   icon: "check-circle"


### PR DESCRIPTION
1. Update to Node20 as Node16 is out of support now within github action.
2. Update to Node20 in github action workflow also.